### PR TITLE
feat: introduce support to specify language version

### DIFF
--- a/Dockerfile.go
+++ b/Dockerfile.go
@@ -1,4 +1,6 @@
-FROM golang:1.17.3-alpine3.14
+ARG VERSION=1.17.3
+
+FROM golang:${VERSION}-alpine3.14
 WORKDIR /go/src/github.com/clastix/simple-app/
 #
 # go mod caching

--- a/Dockerfile.nodejs
+++ b/Dockerfile.nodejs
@@ -1,4 +1,6 @@
-FROM node:17-alpine3.12
+ARG VERSION=17
+
+FROM node:${VERSION}-alpine3.12
 
 ENV NODE_ENV=production
 

--- a/Dockerfile.php
+++ b/Dockerfile.php
@@ -1,4 +1,6 @@
-FROM php:8.0-apache-bullseye
+ARG VERSION=8.0
+
+FROM php:${VERSION}-apache-bullseye
 
 COPY . /var/www/html
 

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,4 +1,6 @@
-FROM python:3.9-alpine
+ARG VERSION=3.9
+
+FROM python:${VERSION}-alpine
 
 COPY . /app
 

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,6 +1,8 @@
+ARG VERSION=1.52.1
+
 FROM alpine:3.14.3
 
-RUN apk add --no-cache rust \
+RUN apk add --no-cache rust=${VERSION}-r1 \
 	&& mkdir /src
 
 COPY ./main.rs /src

--- a/build.yml
+++ b/build.yml
@@ -9,6 +9,8 @@ sources:
   kubectlBuildKit:
     build:
       file: #@ "../1/Dockerfile." + data.values.programming_language_runtime
+      #@ if/end data.values.programming_language_runtime_version:
+      rawOptions: #@ ["--build-arg=VERSION=" + data.values.programming_language_runtime_version]
 
 #@ if/end data.values.push_images_repo:
 ---

--- a/schema.yml
+++ b/schema.yml
@@ -6,4 +6,7 @@ app_name: ""
 #@schema/nullable
 programming_language_runtime: ""
 
+#@schema/nullable
+programming_language_runtime_version: ""
+
 push_images_repo: ""


### PR DESCRIPTION
This PR introduces the abilty to configure the language version at build stage.
This is a primal version. this issue still needs to be tackled:
- language runtimes/compilers version installed with Alpine package manager are not indefinitely stored as explained [here](https://gitlab.alpinelinux.org/alpine/abuild/-/issues/9996#note_87135) (so package version pinning like `go=1.16.10-r0` can stop working when `1.16.10-r1` package release version is published and the `r0` one is removed). This is the case of the Rust language.